### PR TITLE
Add a link of the deployed project in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@
 
 ## Getting Started
 
-**This is an example of how you may give instructions on setting up your project locally.**
-**Modify this file to match your project, remove sections that don't apply. For example: delete the testing section if the currect project doesn't require testing.**
+**This is the link to the deployed page on github https://pazzo97.github.io/Portfolio-project/**
 
 
 ## Authors


### PR DESCRIPTION
This pull request is about the link of project deployment in README.md file